### PR TITLE
Cancel existing orders based on Amwal Order ID

### DIFF
--- a/Cron/PendingOrdersUpdate.php
+++ b/Cron/PendingOrdersUpdate.php
@@ -17,7 +17,6 @@ class PendingOrdersUpdate
     private OrderRepositoryInterface $orderRepository;
     private SearchCriteriaBuilder $searchCriteriaBuilder;
     private LoggerInterface $logger;
-    private GetAmwalOrderData $getAmwalOrderData;
     private Config $config;
     private OrderUpdate $orderUpdate;
 
@@ -26,7 +25,6 @@ class PendingOrdersUpdate
         SearchCriteriaBuilder    $searchCriteriaBuilder,
         LoggerInterface          $logger,
         Config                   $config,
-        GetAmwalOrderData        $getAmwalOrderData,
         OrderUpdate              $orderUpdate
     )
     {
@@ -34,7 +32,6 @@ class PendingOrdersUpdate
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->logger = $logger;
         $this->config = $config;
-        $this->getAmwalOrderData = $getAmwalOrderData;
         $this->orderUpdate = $orderUpdate;
     }
 
@@ -51,32 +48,7 @@ class PendingOrdersUpdate
         $this->logger->notice('Starting Cron Job');
         $orders = $this->getPendingOrders();
         foreach ($orders as $order) {
-            $amwalOrderId = $order->getAmwalOrderId();
-            $orderId = $order->getEntityId();
-
-            if (strpos($amwalOrderId, '-canceled') !== false) {
-                $this->logger->notice(
-                    sprintf('Skipping Order %s as it was canceled because the payment was retried.', $orderId)
-                );
-                continue;
-            }
-
-            if (!$amwalOrderId) {
-                $this->logger->error(sprintf('Order %s does not have an Amwal Order ID', $orderId));
-                continue;
-            }
-
-            $amwalOrderData = $this->getAmwalOrderData->execute($amwalOrderId);
-
-            if ($order->getState() === Order::STATE_CANCELED && $amwalOrderData->getStatus() === 'fail') {
-                continue;
-            }
-
-            if ($amwalOrderData) {
-                $historyComment = __('Successfully completed Amwal payment with transaction ID %1 By Cron Job', $amwalOrderData->getId());
-                $this->orderUpdate->update($order, $amwalOrderData, $historyComment, true);
-                $this->logger->notice(sprintf('Order %s updated successfully', $amwalOrderId));
-            }
+            $this->orderUpdate->update($order, 'PendingOrdersUpdate', true);
         }
         $this->logger->notice('Cron Job Finished');
         return $this;

--- a/Cron/PendingOrdersUpdate.php
+++ b/Cron/PendingOrdersUpdate.php
@@ -52,8 +52,14 @@ class PendingOrdersUpdate
         $orders = $this->getPendingOrders();
         foreach ($orders as $order) {
             $amwalOrderId = $order->getAmwalOrderId();
-            $amwalOrderId = str_replace('-canceled', '', $amwalOrderId);
             $orderId = $order->getEntityId();
+
+            if (strpos($amwalOrderId, '-canceled') !== false) {
+                $this->logger->notice(
+                    sprintf('Skipping Order %s as it was canceled because the payment was retried.', $orderId)
+                );
+                continue;
+            }
 
             if (!$amwalOrderId) {
                 $this->logger->error(sprintf('Order %s does not have an Amwal Order ID', $orderId));

--- a/Cron/PendingOrdersUpdate.php
+++ b/Cron/PendingOrdersUpdate.php
@@ -60,9 +60,13 @@ class PendingOrdersUpdate
             }
             $amwalOrderData = $this->getAmwalOrderData->execute($amwalOrderId);
 
+            if($order->getState() == Order::STATE_CANCELED && $amwalOrderData->getStatus() == 'fail'){
+                continue;
+            }
             if ($amwalOrderData) {
                 $historyComment = __('Successfully completed Amwal payment with transaction ID %1 By Cron Job', $amwalOrderData->getId());
                 $this->orderUpdate->update($order, $amwalOrderData, $historyComment, true);
+                $this->logger->notice(sprintf('Order %s updated successfully', $amwalOrderId));
             }
         }
         $this->logger->notice('Cron Job Finished');
@@ -71,8 +75,8 @@ class PendingOrdersUpdate
 
     protected function getPendingOrders(): array
     {
-        $fromTime = date('Y-m-d h:i', strtotime('-4 hour'));
-        $toTime = date('Y-m-d h:i', strtotime('-1 hour'));
+        $fromTime = date('Y-m-d H:i:s', strtotime('-4 hour'));
+        $toTime = date('Y-m-d H:i:s', strtotime('-1 hour'));
         $this->logger->notice(sprintf('Searching for orders created between %s and %s', $fromTime, $toTime));
 
         $searchCriteria = $this->searchCriteriaBuilder

--- a/Model/Checkout/PayOrder.php
+++ b/Model/Checkout/PayOrder.php
@@ -36,7 +36,6 @@ class PayOrder extends AmwalCheckoutAction
 {
     private CartRepositoryInterface $quoteRepository;
     private CheckoutSession $checkoutSession;
-    private InvoiceOrder $invoiceAmwalOrder;
     private GetAmwalOrderData $getAmwalOrderData;
     private OrderRepositoryInterface $orderRepository;
     private ManagerInterface $messageManager;
@@ -50,7 +49,6 @@ class PayOrder extends AmwalCheckoutAction
     /**
      * @param CartRepositoryInterface $quoteRepository
      * @param CheckoutSession $checkoutSession
-     * @param InvoiceOrder $invoiceAmwalOrder
      * @param GetAmwalOrderData $getAmwalOrderData
      * @param OrderRepositoryInterface $orderRepository
      * @param ManagerInterface $messageManager
@@ -66,7 +64,6 @@ class PayOrder extends AmwalCheckoutAction
     public function __construct(
         CartRepositoryInterface $quoteRepository,
         CheckoutSession $checkoutSession,
-        InvoiceOrder $invoiceAmwalOrder,
         GetAmwalOrderData $getAmwalOrderData,
         OrderRepositoryInterface $orderRepository,
         ManagerInterface $messageManager,
@@ -83,7 +80,6 @@ class PayOrder extends AmwalCheckoutAction
         parent::__construct($errorReporter, $config, $logger);
         $this->quoteRepository = $quoteRepository;
         $this->checkoutSession = $checkoutSession;
-        $this->invoiceAmwalOrder = $invoiceAmwalOrder;
         $this->getAmwalOrderData = $getAmwalOrderData;
         $this->orderRepository = $orderRepository;
         $this->messageManager = $messageManager;
@@ -158,13 +154,13 @@ class PayOrder extends AmwalCheckoutAction
 
         $this->orderUpdate->update($order, $amwalOrderData, '', false);
 
-        if($amwalOrderStatus == 'success') {
+        if ($amwalOrderStatus == 'success') {
             $quote->removeAllItems();
             $this->quoteRepository->save($quote);
             return true;
-        }else{
-            throw new WebapiException(__('We were unable to process your transaction.'), 0, WebapiException::HTTP_BAD_REQUEST);
         }
+
+        throw new WebapiException(__('We were unable to process your transaction.'), 0, WebapiException::HTTP_BAD_REQUEST);
     }
 
     /**

--- a/Model/Checkout/PayOrder.php
+++ b/Model/Checkout/PayOrder.php
@@ -99,8 +99,8 @@ class PayOrder extends AmwalCheckoutAction
     public function execute(int $orderId, string $amwalOrderId) : bool
     {
         $order = $this->orderRepository->get($orderId);
+        $amwalOrderData = $this->orderUpdate->update($order, 'PayOrder', false);
 
-        $amwalOrderData = $this->getAmwalOrderData->execute($amwalOrderId);
         if (!$amwalOrderData) {
             $message = sprintf('Unable to retrieve Amwal Order Data for order with ID "%s". Amwal Order id: %s', $orderId, $amwalOrderId);
             $this->logger->error($message);
@@ -152,7 +152,6 @@ class PayOrder extends AmwalCheckoutAction
             ->setLastRealOrderId($order->getIncrementId())
             ->setLastOrderStatus($order->getStatus());
 
-        $this->orderUpdate->update($order, $amwalOrderData, '', false);
 
         if ($amwalOrderStatus == 'success') {
             $quote->removeAllItems();

--- a/Model/Checkout/PlaceOrder.php
+++ b/Model/Checkout/PlaceOrder.php
@@ -238,7 +238,7 @@ class PlaceOrder extends AmwalCheckoutAction
         $this->logDebug(sprintf('Submitting quote with ID %s', $quote->getId()));
         $order = $this->getOrderByAmwalOrderId($amwalOrderId);
 
-        if ($order) {
+        if ($order && $order->getState() !== Order::STATE_PROCESSING) {
             $this->logDebug(
                 sprintf('Existing order with ID %s found. Canceling order and re-submitting quote.', $order->getEntityId())
             );

--- a/Model/Checkout/PlaceOrder.php
+++ b/Model/Checkout/PlaceOrder.php
@@ -238,15 +238,16 @@ class PlaceOrder extends AmwalCheckoutAction
         $this->logDebug(sprintf('Submitting quote with ID %s', $quote->getId()));
         $order = $this->getOrderByAmwalOrderId($amwalOrderId);
 
-        if ($order === null) {
-            $this->logDebug('No existing order found. Submitting quote.');
-            $order = $this->quoteManagement->submit($quote);
-        } else if (!$order->canEdit()) {
-            $this->logDebug('Existing order found, but it can not be edited. Canceling existing order and submitting quote.');
+        if ($order) {
+            $this->logDebug(
+                sprintf('Existing order with ID %s found. Canceling order and re-submitting quote.', $order->getEntityId())
+            );
             $order->cancel();
-        } else {
-            $this->logDebug('Existing order found. Re-using order without submitting quote.');
+            $order->setAmwalOrderId($amwalOrderId . '-canceled');
+            $this->orderRepository->save($order);
         }
+
+        $order = $this->quoteManagement->submit($quote);
 
         $this->logDebug(sprintf('Quote with ID %s has been submitted', $quote->getId()));
 

--- a/Model/Checkout/PlaceOrder.php
+++ b/Model/Checkout/PlaceOrder.php
@@ -348,7 +348,7 @@ class PlaceOrder extends AmwalCheckoutAction
     private function getOrderByAmwalOrderId($amwalOrderId): ?OrderInterface
     {
         // Build a search criteria to filter orders by custom attribute
-        $searchCriteria = $this->searchCriteriaBuilder->addFilter('amwal_order_id', $amwalOrderId, 'eq');
+        $searchCriteria = $this->searchCriteriaBuilder->addFilter('amwal_order_id', $amwalOrderId);
         $searchCriteria = $searchCriteria->create();
 
         // Search for order with the provided custom attribute value and get the order data

--- a/Model/Config/Frontend/CronStatus.php
+++ b/Model/Config/Frontend/CronStatus.php
@@ -43,11 +43,18 @@ class CronStatus extends Field
         if ($item && $item->getId()) {
             if($item->getScheduledAt()){
                 $nextRun = new \DateTime($item->getScheduledAt());
-                $nextRunFormatted = $nextRun->modify('+1 Hour')->format('Y-m-d H:i:s');
+                $nextRunFormatted = $nextRun->modify('+1 Hour')->format('Y-m-d H:i:s T');
             }else{
                 $nextRunFormatted = 'Not Scheduled';
             }
-            $status = 'Last Run: ' . $item->getExecutedAt() . ' - Next Run: ' . $nextRunFormatted  . ' - Status: ' . $item->getStatus();
+            $lastRun = new \DateTime($item->getExecutedAt());
+            $lastRunFormatted = $lastRun->format('Y-m-d H:i:s T');
+            $status = __(
+                'Last Run: %1 - Next Run:  %2 - Status: %3',
+                $lastRunFormatted,
+                $nextRunFormatted,
+                $item->getStatus()
+            );
             $item->getMessages() ? $status .= ' <br> Messages: ' . $item->getMessages() : '';
         } else {
             $status = 'Cron job has not run yet, please check the crontab in your server';

--- a/Model/Data/AmwalOrderDetails.php
+++ b/Model/Data/AmwalOrderDetails.php
@@ -61,16 +61,13 @@ class AmwalOrderDetails implements AmwalOrderInterface
         $orderId = $requestBody['order_id'];
         $refId = $requestBody['ref_id'];
 
-        $amwalOrderData = $this->getAmwalOrderData->execute($amwalOrderId);
+        $order = $this->getOrderByAmwalOrderId($amwalOrderId, $orderId, $refId);
+        $amwalOrderData = $this->orderUpdate->update($order, 'AmwalOrderDetails', true);
+
         if (!$amwalOrderData) {
             return false;
         }
-        $status = $amwalOrderData['status'];
-
-        $order = $this->getOrderByAmwalOrderId($amwalOrderId, $orderId, $refId);
-        $historyComment = __('Order status updated to (' . $status . ') by Amwal Payments webhook.');
-
-        $this->orderUpdate->update($order, $amwalOrderData, $historyComment, true);
+        return true;
     }
 
     private function getOrderByAmwalOrderId($amwalOrderId, $orderId = null, $refId = null)

--- a/Model/Data/OrderUpdate.php
+++ b/Model/Data/OrderUpdate.php
@@ -93,17 +93,18 @@ class OrderUpdate
                 $order->addStatusHistoryComment($historyComment);
                 $order->setTotalPaid($order->getGrandTotal());
                 $this->setOrderUrl($order, $order->getAmwalOrderId());
-            } elseif($status == 'fail') {
+                // Send customer email
+                $this->sendCustomerEmail($order);
+
+                if($sendAdminEmail) {
+                    // Send admin email
+                    $this->sendAdminEmail($order);
+                }
+            } elseif($status == 'fail' && $order->getState() != Order::STATE_CANCELED) {
                 $order->setState(Order::STATE_CANCELED);
                 $order->setStatus(Order::STATE_CANCELED);
-                $order->addStatusHistoryComment('Amwal Transaction Id: ' . $amwalOrderId . ' has been pending, status: (' . $status . ') and order has been canceled.');
-                $order->addStatusHistoryComment('Amwal Transaction Id: ' . $amwalOrderId . ' Amwal failure reason: ' . $amwalOrderData->getFailureReason());
-            }
-            // Send customer email
-            $this->sendCustomerEmail($order);
-            if($sendAdminEmail) {
-                // Send admin email
-                $this->sendAdminEmail($order);
+                $order->addStatusHistoryComment('Amwal Transaction Id: ' . $amwalOrderData->getId() . ' has been pending, status: (' . $status . ') and order has been canceled.');
+                $order->addStatusHistoryComment('Amwal Transaction Id: ' . $amwalOrderData->getId() . ' Amwal failure reason: ' . $amwalOrderData->getFailureReason());
             }
             // Save the updated order
             $this->orderRepository->save($order);

--- a/Plugin/Sales/Order/View/Details.php
+++ b/Plugin/Sales/Order/View/Details.php
@@ -43,6 +43,11 @@ class Details
         $amwalClient = $this->amwalClientFactory->create();
 
         try {
+            // check if the $amwalOrderId have -canceled suffix
+            if (strpos($amwalOrderId, '-canceled') !== false) {
+                return;
+            }
+
             $response = $amwalClient->get('transactions/' . $amwalOrderId);
 
             if ($response->getStatusCode() === 200) {


### PR DESCRIPTION
When the place order call fails the order may have been created. If we retry the payment the original order should be canceled to prevent duplicated which are stuck in "Pending Payment"