### PR TITLE
Add check for the method availability

### DIFF
--- a/Model/Checkout/GetQuote.php
+++ b/Model/Checkout/GetQuote.php
@@ -420,10 +420,14 @@ class GetQuote extends AmwalCheckoutAction
             if (empty($rate->getMethodTitle())) {
                 $this->logger->warning('Shipping method title is empty. Falling back to ID as title: ' . $id);
             }
-            $availableRates[$id] = [
-                'carrier_title' => $rate->getMethodTitle() ?? $id,
-                'price' => number_format((float)$rate->getPriceInclTax(), 2)
-            ];
+            if ($rate->getAvailable()) {
+                $availableRates[$id] = [
+                    'carrier_title' => $rate->getMethodTitle() ?? $id,
+                    'price' => number_format((float)$rate->getPriceInclTax(), 2)
+                ];
+            }else{
+                $this->logger->warning('Shipping method: ' . $id . ' have a error: ' . $rate->getErrorMessage());
+            }
         }
         try {
             $this->logDebug(sprintf(

--- a/Test/Unit/Model/Checkout/GetQuoteTest.php
+++ b/Test/Unit/Model/Checkout/GetQuoteTest.php
@@ -381,13 +381,14 @@ class GetQuoteTest extends TestCase
     private function createRateMock(string $carrierCode, string $methodCode, string $methodTitle, float $priceInclTax): MockObject
     {
         $rateMock = $this->getMockBuilder(ShippingMethodInterface::class)
-            ->onlyMethods(['getCarrierCode', 'getMethodCode', 'getMethodTitle', 'getPriceInclTax'])
+            ->onlyMethods(['getCarrierCode', 'getMethodCode', 'getMethodTitle', 'getPriceInclTax', 'getAvailable'])
             ->getMockForAbstractClass();
 
         $rateMock->method('getCarrierCode')->willReturn($carrierCode);
         $rateMock->method('getMethodCode')->willReturn($methodCode);
         $rateMock->method('getMethodTitle')->willReturn($methodTitle);
         $rateMock->method('getPriceInclTax')->willReturn($priceInclTax);
+        $rateMock->method('getAvailable')->willReturn(true);
 
         return $rateMock;
     }


### PR DESCRIPTION
# Issue:
When attempting to place an order, we are encountering a situation where all enabled shipping methods are being retrieved, rather than only the active shipping methods.

![image](https://github.com/amwal-tech/amwal-magento/assets/141551822/45c99561-03bf-4b4c-9b1d-66295db26462)
![image](https://github.com/amwal-tech/amwal-magento/assets/141551822/79fc2577-e783-4ef4-a931-1ad2cd883f77)

```
{
    "message": "The shipping method is missing. Select the shipping method and try again.",
    "parameters": [
        ""
    ],
    "trace": "#0 \/var\/www\/html\/vendor\/magento\/module-quote\/Model\/SubmitQuoteValidator.php(52): Magento\\Quote\\Model\\QuoteValidator->validateBeforeSubmit()\n#1 \/var\/www\/html\/vendor\/magento\/module-quote\/Model\/QuoteManagement.php(529): Magento\\Quote\\Model\\SubmitQuoteValidator->validateQuote()\n#2 \/var\/www\/html\/vendor\/magento\/module-quote\/Model\/QuoteManagement.php(483): Magento\\Quote\\Model\\QuoteManagement->submitQuote()\n#3 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(58): Magento\\Quote\\Model\\QuoteManagement->submit()\n#4 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(138): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->___callParent()\n#5 \/var\/www\/html\/vendor\/magento\/module-sales-rule\/Plugin\/CouponUsagesIncrement.php(54): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->Magento\\Framework\\Interception\\{closure}()\n#6 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(135): Magento\\SalesRule\\Plugin\\CouponUsagesIncrement->aroundSubmit()\n#7 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(153): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->Magento\\Framework\\Interception\\{closure}()\n#8 \/var\/www\/html\/generated\/code\/Magento\/Quote\/Model\/QuoteManagement\/Interceptor.php(32): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->___callPlugins()\n#9 \/var\/www\/html\/vendor\/magento\/module-quote\/Model\/QuoteManagement.php(441): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->submit()\n#10 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(58): Magento\\Quote\\Model\\QuoteManagement->placeOrder()\n#11 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(138): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->___callParent()\n#12 \/var\/www\/html\/vendor\/paypal\/module-braintree-core\/Plugin\/OrderCancellation.php(63): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->Magento\\Framework\\Interception\\{closure}()\n#13 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(135): PayPal\\Braintree\\Plugin\\OrderCancellation->aroundPlaceOrder()\n#14 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(153): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->Magento\\Framework\\Interception\\{closure}()\n#15 \/var\/www\/html\/generated\/code\/Magento\/Quote\/Model\/QuoteManagement\/Interceptor.php(23): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->___callPlugins()\n#16 \/var\/www\/html\/vendor\/amwal\/payments\/Model\/Checkout\/PlaceOrder.php(255): Magento\\Quote\\Model\\QuoteManagement\\Interceptor->placeOrder()\n#17 \/var\/www\/html\/vendor\/amwal\/payments\/Model\/Checkout\/PlaceOrder.php(220): Amwal\\Payments\\Model\\Checkout\\PlaceOrder->createOrder()\n#18 [internal function]: Amwal\\Payments\\Model\\Checkout\\PlaceOrder->execute()\n#19 \/var\/www\/html\/vendor\/magento\/module-webapi\/Controller\/Rest\/SynchronousRequestProcessor.php(95): call_user_func_array()\n#20 \/var\/www\/html\/vendor\/magento\/module-webapi\/Controller\/Rest.php(188): Magento\\Webapi\\Controller\\Rest\\SynchronousRequestProcessor->process()\n#21 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(58): Magento\\Webapi\\Controller\\Rest->dispatch()\n#22 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(138): Magento\\Webapi\\Controller\\Rest\\Interceptor->___callParent()\n#23 \/var\/www\/html\/vendor\/magento\/framework\/Interception\/Interceptor.php(153): Magento\\Webapi\\Controller\\Rest\\Interceptor->Magento\\Framework\\Interception\\{closure}()\n#24 \/var\/www\/html\/generated\/code\/Magento\/Webapi\/Controller\/Rest\/Interceptor.php(23): Magento\\Webapi\\Controller\\Rest\\Interceptor->___callPlugins()\n#25 \/var\/www\/html\/vendor\/magento\/framework\/App\/Http.php(116): Magento\\Webapi\\Controller\\Rest\\Interceptor->dispatch()\n#26 \/var\/www\/html\/vendor\/magento\/framework\/App\/Bootstrap.php(264): Magento\\Framework\\App\\Http->launch()\n#27 \/var\/www\/html\/pub\/index.php(30): Magento\\Framework\\App\\Bootstrap->run()\n#28 {main}"
}

```