### PR TITLE
Fix issue with undefined method getContent()

### DIFF
--- a/Plugin/Checkout/EnrichAddToCartResponse.php
+++ b/Plugin/Checkout/EnrichAddToCartResponse.php
@@ -18,6 +18,7 @@ use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Message\MessageInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Multishipping\Model\DisableMultishipping;
+use Magento\Framework\Controller\Result\Json as JsonResult;
 
 class EnrichAddToCartResponse
 {
@@ -55,6 +56,11 @@ class EnrichAddToCartResponse
         $lastMessage = $this->messageManager->getMessages()->getLastAddedMessage();
 
         if (!$lastMessage || $lastMessage->getType() !== MessageInterface::TYPE_ERROR || !$lastMessage->getText()) {
+            return $result;
+        }
+
+        // Check if the result is a JSON response
+        if (!$result instanceof JsonResult) {
             return $result;
         }
 


### PR DESCRIPTION
Fix issue with undefined method getContent() by checking result type in EnrichAddToCartResponse plugin

Reported Issue:
`#22 {main} {"exception":"[object] (Error(code: 0): Call to undefined method Magento\\Framework\\Controller\\Result\\Redirect\\Interceptor::getContent() at /chroot/home/a4beefb1/c4613b6d9b.nxcli.net/vendor/amwal/payments/Plugin/Checkout/EnrichAddToCartResponse.php:61)"} []`