### PR TITLE
Refactor: Set quote payment method using importData for flexibility

### DIFF
--- a/Model/Checkout/PlaceOrder.php
+++ b/Model/Checkout/PlaceOrder.php
@@ -166,7 +166,7 @@ class PlaceOrder extends AmwalCheckoutAction
         $quote = $this->quoteRepository->get($quoteId);
         $this->virtualItemSupport($quote);
         $quote->setData(self::IS_AMWAL_API_CALL, true);
-        $quote->setPaymentMethod($paymentMethod ?? ConfigProvider::CODE);
+        $quote->getPayment()->importData(['method' => $paymentMethod ?? ConfigProvider::CODE]);
 
         $customerAddress = null;
         if ($hasAmwalAddress) {


### PR DESCRIPTION
Updated the quote payment method assignment to use `importData` on the payment object, allowing for more dynamic configuration and support for null-coalescing logic with `ConfigProviders::CODE`.