### PR TITLE
fix: add missing mage/validation dependency to checkout button

### DIFF
--- a/view/frontend/web/js/checkout-button.js
+++ b/view/frontend/web/js/checkout-button.js
@@ -8,6 +8,7 @@ define([
     'Magento_Customer/js/customer-data',
     'underscore',
     'mage/translate',
+    'mage/validation',
     'domReady!'
 ],
 function ($, Component, placeAmwalOrder, payAmwalOrder, amwalErrorHandler, urlBuilder, customerData, _) {
@@ -103,7 +104,10 @@ function ($, Component, placeAmwalOrder, payAmwalOrder, amwalErrorHandler, urlBu
              * @return Boolean
              */
             const isProductFormValid = () => {
-                addToCartForm.validation();
+                // Initialize validation if not already done
+                if (!addToCartForm.data('validation')) {
+                    addToCartForm.validation();
+                }
                 const formIsValid = addToCartForm.validation('isValid');
                 addToCartForm.validation('clearError');
                 return formIsValid;


### PR DESCRIPTION
- Add mage/validation module to dependencies array
- Initialize form validation before calling validation methods
- Add defensive check to ensure validation is available before use
- Fixes 'addToCartForm.validation is not a function' error