### PR TITLE
Refactor locale assignment for promotion widget

### DIFF
--- a/view/frontend/templates/product/promotion.phtml
+++ b/view/frontend/templates/product/promotion.phtml
@@ -14,8 +14,7 @@ use Magento\Framework\View\Element\Template;
             const widgetConfig = {
                 installmentsCount: <?= (int) $block->getInstallmentsCount() ?>,
                 price: <?= (float) $block->getPrice() ?>,
-                currency: "SAR",
-                locale: document.documentElement.lang || 'en'
+                currency: "SAR"
             };
             // Initialize when DOM is ready
             require(['jquery'], function ($) {
@@ -23,6 +22,7 @@ use Magento\Framework\View\Element\Template;
                     const widget = document.getElementById('amwal-widget');
                     if (widget) {
                         widget.config = widgetConfig;
+                        widget.locale = document.documentElement.lang || 'en'
                     }
                 } catch (error) {
                     console.error('Amwal Promotion: Error initializing widget', error);

--- a/view/frontend/templates/product/promotion.phtml
+++ b/view/frontend/templates/product/promotion.phtml
@@ -22,7 +22,7 @@ use Magento\Framework\View\Element\Template;
                     const widget = document.getElementById('amwal-widget');
                     if (widget) {
                         widget.config = widgetConfig;
-                        widget.locale = document.documentElement.lang || 'en'
+                        widget.locale = document.documentElement.lang || 'en';
                     }
                 } catch (error) {
                     console.error('Amwal Promotion: Error initializing widget', error);


### PR DESCRIPTION
Moved the locale assignment for the Amwal promotion widget from the config object to a direct property on the widget element. This change clarifies the separation of configuration and localization.