### PR TITLE
Restore stock quantities on order payment failure

### DIFF
--- a/Model/Event/OrderFailed.php
+++ b/Model/Event/OrderFailed.php
@@ -7,6 +7,12 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Model\Order;
 use Psr\Log\LoggerInterface;
+use Magento\CatalogInventory\Api\StockManagementInterface;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterfaceFactory;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventorySalesAdminUi\Model\GetSalableQuantityDataBySku;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
  * Handles order.failed webhook event
@@ -30,18 +36,50 @@ class OrderFailed implements HandlerInterface
     private $logger;
 
     /**
+     * @var StockManagementInterface
+     */
+    private $stockManagement;
+
+    /**
+     * @var SourceItemsSaveInterface
+     */
+    private $sourceItemsSave;
+
+    /**
+     * @var SourceItemInterfaceFactory
+     */
+    private $sourceItemFactory;
+
+    /**
+     * @var GetSalableQuantityDataBySku
+     */
+    private $getSalableQuantityDataBySku;
+
+    /**
      * @param OrderRepositoryInterface $orderRepository
      * @param OrderManagementInterface $orderManagement
      * @param LoggerInterface $logger
+     * @param StockManagementInterface $stockManagement
+     * @param SourceItemsSaveInterface $sourceItemsSave
+     * @param SourceItemInterfaceFactory $sourceItemFactory
+     * @param GetSalableQuantityDataBySku $getSalableQuantityDataBySku
      */
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         OrderManagementInterface $orderManagement,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        StockManagementInterface $stockManagement,
+        SourceItemsSaveInterface $sourceItemsSave,
+        SourceItemInterfaceFactory $sourceItemFactory,
+        GetSalableQuantityDataBySku $getSalableQuantityDataBySku
     ) {
         $this->orderRepository = $orderRepository;
         $this->orderManagement = $orderManagement;
         $this->logger = $logger;
+        $this->stockManagement = $stockManagement;
+        $this->sourceItemsSave = $sourceItemsSave;
+        $this->sourceItemFactory = $sourceItemFactory;
+        $this->getSalableQuantityDataBySku = $getSalableQuantityDataBySku;
     }
 
     /**
@@ -84,6 +122,9 @@ class OrderFailed implements HandlerInterface
             // Save payment changes
             $this->orderRepository->save($order);
 
+            // Restore stock before canceling
+            $this->restoreOrderStock($order);
+
             // Cancel the order
             if ($order->canCancel()) {
                 // Explicitly set both state and status to CANCELED
@@ -92,7 +133,7 @@ class OrderFailed implements HandlerInterface
 
                 // Add comment with payment failure reason
                 $comment = $order->addCommentToStatusHistory(
-                    __('[Webhook] Payment failed with Amwal. Reason: %1', $reason),
+                    __('[Webhook] Payment failed with Amwal. Reason: %1. Stock quantities restored.', $reason),
                     Order::STATE_CANCELED,
                     true
                 );
@@ -120,7 +161,7 @@ class OrderFailed implements HandlerInterface
 
                 // Add another comment confirming cancellation
                 $updatedOrder->addCommentToStatusHistory(
-                    __('[Webhook] Order was cancelled due to payment failure with Amwal.'),
+                    __('[Webhook] Order was cancelled due to payment failure with Amwal. Stock restored.'),
                     Order::STATE_CANCELED,
                     true
                 );
@@ -128,7 +169,7 @@ class OrderFailed implements HandlerInterface
                 // Save the order again to ensure the confirmation comment is saved
                 $this->orderRepository->save($updatedOrder);
 
-                $this->logger->info("Order #{$order->getIncrementId()} cancelled due to payment failure");
+                $this->logger->info("Order #{$order->getIncrementId()} cancelled due to payment failure and stock restored");
             } else {
                 // If order cannot be cancelled, just add a comment
                 // Set a proper status even if we can't cancel
@@ -139,7 +180,7 @@ class OrderFailed implements HandlerInterface
                 $order->setStatus($paymentFailedStatus);
 
                 $comment = $order->addCommentToStatusHistory(
-                    __('[Webhook] Payment failed with Amwal but order could not be cancelled. Reason: %1', $reason),
+                    __('[Webhook] Payment failed with Amwal but order could not be cancelled. Reason: %1. Stock restored.', $reason),
                     $paymentFailedStatus,
                     true
                 );
@@ -152,7 +193,7 @@ class OrderFailed implements HandlerInterface
                 }
 
                 $this->orderRepository->save($order);
-                $this->logger->info("Order #{$order->getIncrementId()} could not be cancelled. Added comment only. Status set to: {$paymentFailedStatus}");
+                $this->logger->info("Order #{$order->getIncrementId()} could not be cancelled. Added comment only. Status set to: {$paymentFailedStatus}. Stock restored.");
             }
         } catch (\Exception $e) {
             $this->logger->critical(
@@ -160,6 +201,80 @@ class OrderFailed implements HandlerInterface
                 ['exception' => $e]
             );
             throw new LocalizedException(__('Error processing payment failure: %1', $e->getMessage()));
+        }
+    }
+
+    /**
+     * Restore stock for order items
+     *
+     * @param Order $order
+     * @return void
+     */
+    private function restoreOrderStock(Order $order)
+    {
+        try {
+            $this->logger->info("Starting stock restoration for order #{$order->getIncrementId()}");
+
+            $items = $order->getAllVisibleItems();
+            $sourceItemsToSave = [];
+
+            foreach ($items as $item) {
+                if ($item->getProductType() === 'simple') {
+                    $sku = $item->getSku();
+                    $qtyOrdered = (float)$item->getQtyOrdered();
+
+                    $this->logger->info("Restoring stock for SKU: {$sku}, Quantity: {$qtyOrdered}");
+
+                    try {
+                        // Method 1: Using legacy stock management (works with older Magento versions)
+                        $this->stockManagement->backItemQty($sku, $qtyOrdered);
+
+                        $this->logger->info("Successfully restored {$qtyOrdered} units for SKU: {$sku} using legacy method");
+
+                    } catch (\Exception $legacyException) {
+                        $this->logger->warning("Legacy stock restoration failed for SKU: {$sku}. Trying MSI method. Error: " . $legacyException->getMessage());
+
+                        try {
+                            // Method 2: Using MSI (Multi-Source Inventory) for newer Magento versions
+                            $salableQuantityData = $this->getSalableQuantityDataBySku->execute($sku);
+
+                            foreach ($salableQuantityData as $sourceData) {
+                                $sourceCode = $sourceData['source_code'];
+
+                                $sourceItem = $this->sourceItemFactory->create();
+                                $sourceItem->setSourceCode($sourceCode);
+                                $sourceItem->setSku($sku);
+                                $sourceItem->setQuantity($sourceData['qty'] + $qtyOrdered);
+                                $sourceItem->setStatus(SourceItemInterface::STATUS_IN_STOCK);
+
+                                $sourceItemsToSave[] = $sourceItem;
+
+                                $this->logger->info("Prepared to restore {$qtyOrdered} units for SKU: {$sku} in source: {$sourceCode}");
+                                break; // Use the first available source
+                            }
+
+                        } catch (\Exception $msiException) {
+                            $this->logger->error("MSI stock restoration also failed for SKU: {$sku}. Error: " . $msiException->getMessage());
+                        }
+                    }
+                }
+            }
+
+            // Save MSI source items if any were prepared
+            if (!empty($sourceItemsToSave)) {
+                try {
+                    $this->sourceItemsSave->execute($sourceItemsToSave);
+                    $this->logger->info("Successfully saved MSI stock updates for order #{$order->getIncrementId()}");
+                } catch (\Exception $saveException) {
+                    $this->logger->error("Failed to save MSI stock updates for order #{$order->getIncrementId()}: " . $saveException->getMessage());
+                }
+            }
+
+            $this->logger->info("Completed stock restoration for order #{$order->getIncrementId()}");
+
+        } catch (\Exception $e) {
+            $this->logger->error("Error during stock restoration for order #{$order->getIncrementId()}: " . $e->getMessage());
+            // Don't throw exception here to avoid blocking the order cancellation
         }
     }
 }


### PR DESCRIPTION
Adds logic to restore stock for order items when a payment fails, supporting both legacy and MSI inventory systems. Updates order comments and logs to reflect stock restoration during cancellation or status update.