### PR TITLE
Use Arabic city name if locale is Arabic

### DIFF
--- a/Model/ThirdParty/CityHelper.php
+++ b/Model/ThirdParty/CityHelper.php
@@ -46,7 +46,7 @@ class CityHelper
                 ->where($condition);
 
             foreach ($connection->fetchAll($sql) as $city) {
-                $cityCodes[$city['country_id']][$city['state_id']][] = $city['city'];
+                $cityCodes[$city['country_id']][$city['state_id']][] = (strpos($this->localeResolver->getLocale(), 'ar') !== false && !empty($city['city_ar'])) ? $city['city_ar'] : ($city['city'] ?? '');
             }
         }
 

--- a/Model/ThirdParty/CityHelper.php
+++ b/Model/ThirdParty/CityHelper.php
@@ -120,7 +120,7 @@ class CityHelper
 
     private function getLocalizedCityName(?string $default, ?string $arabic): string
     {
-        $isArabic = strpos($this->localeResolver->getLocale(), 'ar') !== false;
+        $isArabic = str_starts_with($this->localeResolver->getLocale(), 'ar');
         return $isArabic && !empty($arabic) ? $arabic : ($default ?? '');
     }
 }


### PR DESCRIPTION
Updated CityHelper to select the Arabic city name when the current locale is Arabic and the Arabic name is available. Falls back to the default city name if not.