### PR TITLE
Refactor CleanQuote to improve quote cleanup logic

### DIFF
--- a/Model/Checkout/CleanQuote.php
+++ b/Model/Checkout/CleanQuote.php
@@ -7,7 +7,6 @@ use Amwal\Payments\Model\Config;
 use Amwal\Payments\Model\ErrorReporter;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Psr\Log\LoggerInterface;
 
@@ -17,6 +16,8 @@ class CleanQuote extends AmwalCheckoutAction
     private CartRepositoryInterface $cartRepository;
 
     /**
+     * CleanQuote constructor.
+     *
      * @param CheckoutSession $checkoutSession
      * @param CartRepositoryInterface $cartRepository
      * @param ErrorReporter $errorReporter
@@ -36,25 +37,26 @@ class CleanQuote extends AmwalCheckoutAction
     }
 
     /**
-     * @return void
+     * Execute the quote cleaning process
      */
     public function execute(): void
     {
         try {
             $quote = $this->checkoutSession->getQuote();
-        } catch (NoSuchEntityException|LocalizedException $e) {
-            $this->logDebug('No existing quote found, skipping cleanup.');
-            return;
-        }
 
-        if (!$quote) {
-            $this->logDebug('No existing quote found, skipping cleanup.');
-            return;
-        }
+            if ($quote && $quote->getId()) {
+                $this->logDebug('Deactivating quote: ' . $quote->getId());
 
-        $this->logDebug('Starting Quote cleanup.');
-        $quote->removeAllItems();
-        $this->cartRepository->save($quote);
-        $this->logDebug('Quote cleanup completed.');
+                $quote->setIsActive(false);
+                $this->cartRepository->save($quote);
+            }
+            $this->checkoutSession->clearQuote();
+            $this->checkoutSession->clearStorage();
+
+            $this->logDebug('Quote cleaned successfully. New quote will be created automatically.');
+
+        } catch (\Exception $e) {
+            $this->logDebug('Error cleaning quote: ' . $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
Simplified the quote cleanup process by deactivating and saving the quote only if it exists and has an ID. Removed unnecessary exception handling for NoSuchEntityException and LocalizedException, and added more robust error logging. The session is now cleared after deactivating the quote, and log messages have been updated for clarity.