### PR TITLE
Add checkout promotions toggle to config and frontend

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -72,6 +72,7 @@ class Config
     public const XML_CONFIG_PATH_WEBHOOK_DEBUG = 'payment/amwal_payments/webhook/debug';
     public const XML_CONFIG_PATH_BANK_INSTALLMENTS_TIMELINE_STYLE = 'payment/amwal_payments/bank_installments_timeline_style';
     public const XML_CONFIG_PATH_BANK_INSTALLMENTS_FOOTER_MESSAGE = 'payment/amwal_payments/bank_installments_footer_message';
+    public const XML_CONFIG_PATH_CHECKOUT_PROMOS_ACTIVE = 'payment/amwal_payments/checkout_promotions';
 
   /**
      * @var string
@@ -657,4 +658,13 @@ class Config
     {
         return (string) $this->scopeConfig->getValue(self::XML_CONFIG_PATH_BANK_INSTALLMENTS_FOOTER_MESSAGE, ScopeInterface::SCOPE_WEBSITE);
     }
+
+    /**
+     * @return bool
+     */
+    public function isCheckoutPromosActive(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_CONFIG_PATH_CHECKOUT_PROMOS_ACTIVE, ScopeInterface::SCOPE_WEBSITE);
+    }
+
 }

--- a/Model/Config/Checkout/ConfigProvider.php
+++ b/Model/Config/Checkout/ConfigProvider.php
@@ -134,6 +134,7 @@ class ConfigProvider implements ConfigProviderInterface
             'isBankInstallmentsActive' => $this->isBankInstallmentsActive(),
             'defaultRedirectUrl' => $this->urlInterface->getUrl('amwal/redirect'),
             'isRegularCheckoutRedirect' => $this->config->isRegularCheckoutRedirect(),
+            'isCheckoutPromosActive' => $this->config->isCheckoutPromosActive(),
         ];
 
         return [

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -37,6 +37,7 @@
                 <redirect_on_load_click>0</redirect_on_load_click>
                 <product_promotions>1</product_promotions>
                 <cart_promotions>1</cart_promotions>
+                <checkout_promotions>1</checkout_promotions>
             </amwal_payments>
             <amwal_payments_apple_pay>
                 <title>Amwal apple pay</title>

--- a/view/adminhtml/templates/system/config/create_api_key.phtml
+++ b/view/adminhtml/templates/system/config/create_api_key.phtml
@@ -17,7 +17,7 @@
             // API key creation button click handler
             $('#<?= $block->getHtmlId() ?>_button').click(function() {
                 // Get webhook URL
-                var webhookUrl = document.querySelector('[name="groups[amwal_payments][groups][webhook][fields][endpoint_url][value]"]').value
+                var webhookUrl = document.querySelector('[name="groups[amwal_payments][groups][webhook][fields][endpoint_url][value]"]').value;
                 // get webhook events
                 var webhookEvents =  $('input[name="groups[amwal][fields][webhook_events][value][]"]:checked').map(function() {
                     return this.value;

--- a/view/frontend/web/js/view/checkout/sidebar/promotion.js
+++ b/view/frontend/web/js/view/checkout/sidebar/promotion.js
@@ -15,6 +15,11 @@ define([
 
         initialize: function () {
             this._super();
+            let config = window.checkoutConfig.payment;
+            let methodCode = 'amwal_payments';
+            if (!config[methodCode]?.isCheckoutPromosActive) {
+                return this;
+            }
             this.visible = ko.observable(true);
             this.widgetElement = null;
 


### PR DESCRIPTION
Introduces a new 'checkout_promotions' config option, exposes it via the Config and ConfigProvider classes, and updates the frontend promotion widget to respect this setting. Also includes a minor code style fix in the admin API key template.