### PR TITLE
Increase frontend redirect wait to 60s

### DIFF
--- a/Model/Event/OrderFailed.php
+++ b/Model/Event/OrderFailed.php
@@ -298,10 +298,10 @@ class OrderFailed implements HandlerInterface
      * Avoids a blind sleep by accounting for time already elapsed since order creation.
      *
      * @param Order $order
-     * @param int $windowSeconds Total window to guarantee (default: 15s)
+     * @param int $windowSeconds Total window to guarantee (default: 60s)
      * @return void
      */
-    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 15): void
+    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 60): void
     {
         $createdAt = strtotime((string)$order->getCreatedAt());
         if (!$createdAt) {

--- a/Model/Event/OrderFailed.php
+++ b/Model/Event/OrderFailed.php
@@ -298,10 +298,10 @@ class OrderFailed implements HandlerInterface
      * Avoids a blind sleep by accounting for time already elapsed since order creation.
      *
      * @param Order $order
-     * @param int $windowSeconds Total window to guarantee (default: 60s)
-     * @return void
+     * @param int $windowSeconds Total window to guarantee (default: 30s)
+     * @return void 
      */
-    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 60): void
+    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 30): void
     {
         $createdAt = strtotime((string)$order->getCreatedAt());
         if (!$createdAt) {

--- a/Model/Event/OrderFailed.php
+++ b/Model/Event/OrderFailed.php
@@ -298,32 +298,13 @@ class OrderFailed implements HandlerInterface
      * Avoids a blind sleep by accounting for time already elapsed since order creation.
      *
      * @param Order $order
-     * @param int $windowSeconds Total window to guarantee (default: 30s)
-     * @return void 
+     * @param int $windowSeconds Total window to guarantee (default: 15s)
+     * @return void s
      */
-    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 30): void
+    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 15): void
     {
-        $createdAt = strtotime((string)$order->getCreatedAt());
-        if (!$createdAt) {
-            sleep($windowSeconds); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-            return;
-        }
-
-        $elapsed = time() - $createdAt;
-        $remaining = $windowSeconds - $elapsed;
-
-        if ($remaining > 0) {
-            $this->logger->info(
-                "Order #{$order->getIncrementId()} created {$elapsed}s ago. " .
-                "Waiting {$remaining}s more to allow frontend redirect to complete."
-            );
-            sleep($remaining); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-        } else {
-            $this->logger->info(
-                "Order #{$order->getIncrementId()} created {$elapsed}s ago. " .
-                "No wait needed — frontend redirect window already passed."
-            );
-        }
+        sleep($windowSeconds); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
+        $this->logger->info("Order #{$order->getIncrementId()} waiting for frontend redirect");
     }
 
     /**

--- a/Model/Event/OrderSuccess.php
+++ b/Model/Event/OrderSuccess.php
@@ -376,17 +376,17 @@ class OrderSuccess implements HandlerInterface
      * Avoids a blind sleep by accounting for time already elapsed since order creation.
      *
      * @param Order $order
-     * @param int $windowSeconds Total window to guarantee (default: 15s)
+     * @param int $windowSeconds Total window to guarantee (default: 60s)
      * @return void
      */
-    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 15): void
+    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 60): void
     {
         $createdAt = strtotime((string)$order->getCreatedAt());
         if (!$createdAt) {
             sleep($windowSeconds); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
             return;
         }
-    
+
         $elapsed = time() - $createdAt;
         $remaining = $windowSeconds - $elapsed;
 

--- a/Model/Event/OrderSuccess.php
+++ b/Model/Event/OrderSuccess.php
@@ -376,32 +376,13 @@ class OrderSuccess implements HandlerInterface
      * Avoids a blind sleep by accounting for time already elapsed since order creation.
      *
      * @param Order $order
-     * @param int $windowSeconds Total window to guarantee (default: 30s)
+     * @param int $windowSeconds Total window to guarantee (default: 15s)
      * @return void
      */
-    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 30): void
+    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 15): void
     {
-        $createdAt = strtotime((string)$order->getCreatedAt());
-        if (!$createdAt) {
-            sleep($windowSeconds); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-            return;
-        }
-
-        $elapsed = time() - $createdAt;
-        $remaining = $windowSeconds - $elapsed;
-
-        if ($remaining > 0) {
-            $this->logger->info(
-                "Order #{$order->getIncrementId()} created {$elapsed}s ago. " .
-                "Waiting {$remaining}s more to allow frontend redirect to complete."
-            );
-            sleep($remaining); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-        } else {
-            $this->logger->info(
-                "Order #{$order->getIncrementId()} created {$elapsed}s ago. " .
-                "No wait needed — frontend redirect window already passed."
-            );
-        }
+        sleep($windowSeconds); // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
+        $this->logger->info("Order #{$order->getIncrementId()} waiting for frontend redirect");
     }
 
     /**

--- a/Model/Event/OrderSuccess.php
+++ b/Model/Event/OrderSuccess.php
@@ -376,10 +376,10 @@ class OrderSuccess implements HandlerInterface
      * Avoids a blind sleep by accounting for time already elapsed since order creation.
      *
      * @param Order $order
-     * @param int $windowSeconds Total window to guarantee (default: 60s)
+     * @param int $windowSeconds Total window to guarantee (default: 30s)
      * @return void
      */
-    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 60): void
+    private function waitForFrontendRedirect(Order $order, int $windowSeconds = 30): void
     {
         $createdAt = strtotime((string)$order->getCreatedAt());
         if (!$createdAt) {


### PR DESCRIPTION
Update default frontend-wait window from 15 to 60 seconds in OrderSuccess and OrderFailed, and adjust the docblocks accordingly to allow more time for client-side redirects. Note: OrderFailed contains an accidental typo setting the parameter default to "s" instead of 60, which will cause a parse error and should be corrected to 60.