### PR TITLE
Support libphonenumber v9 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "homepage": "https://amwal.tech",
     "require": {
         "php": ">=7.4.0",
-        "giggsey/libphonenumber-for-php": "^8.13.7",
+        "giggsey/libphonenumber-for-php": "^8.13.7 || ^9.0",
         "sentry/sdk": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Broaden the version constraint for giggsey/libphonenumber-for-php from ^8.13.7 to ^8.13.7 || ^9.0 so the project can accept either the existing 8.x releases or the new 9.x release. No other dependencies were modified.