### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - php-version: '8.1'
           - php-version: '8.2'
           - php-version: '8.3'
+          - php-version: '8.4'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - develop
-  workflow_dispatch:
+  workflow_dispatch:  # Only allow manual triggering
 
 jobs:
   deploy:


### PR DESCRIPTION
Include PHP 8.4 in the GitHub Actions CI matrix to run tests against the upcoming PHP version. Update the deploy workflow to remove the automatic push trigger on the develop branch and allow only manual workflow_dispatch triggers to prevent unintended automatic deployments.