### PR TITLE
Address/Checkout: region/phone handling & error fixes

### DIFF
--- a/Model/AddressResolver.php
+++ b/Model/AddressResolver.php
@@ -367,47 +367,16 @@ class AddressResolver
      */
     private function getFormattedPhoneNumber(string $rawPhoneNumber): string
     {
-        $format = $this->config->getPhoneNumberFormat();
-        $formattedNumber = $rawPhoneNumber;
         if ($rawPhoneNumber === self::TEMPORARY_DATA_VALUE) {
             return $rawPhoneNumber;
         }
 
+        $format = $this->config->getPhoneNumberFormat();
+        $formattedNumber = $rawPhoneNumber;
+
         if (class_exists('libphonenumber\PhoneNumberUtil') &&
             in_array($format, PhoneNumberFormat::getValidValues())) {
-            $phoneNumberUtil = PhoneNumberUtil::getInstance();
-            try {
-                $phoneNumber = $phoneNumberUtil->parse($rawPhoneNumber);
-            } catch (NumberParseException $e) {
-                $this->logger->error(sprintf(
-                    'Unable to parse phone number "%s" for formatting: %s',
-                    $rawPhoneNumber,
-                    $e->getMessage()
-                ));
-                return $rawPhoneNumber;
-            }
-
-            if ($format === PhoneNumberFormat::COUNTRY_OPTION_VALUE) {
-                $country = $this->config->getPhoneNumberFormatCountry();
-                if (!$country) {
-                    $this->logger->error(sprintf(
-                        'Unable to parse phone number "%s" for formatting. Country must be specified when country formatting is selected.',
-                        $rawPhoneNumber
-                    ));
-                    return $rawPhoneNumber;
-                }
-                $formattedNumber = $phoneNumberUtil->formatOutOfCountryCallingNumber($phoneNumber, $country);
-            } elseif ($format === 'raw') {
-                // 'raw' means no libphonenumber formatting — return as-is
-                return $rawPhoneNumber;
-            } else {
-                // libphonenumber v9 uses backed enums; cast stored int/string value to enum if needed
-                $libFormat = $format;
-                if (!($format instanceof \BackedEnum)) {
-                    $libFormat = \libphonenumber\PhoneNumberFormat::from((int) $format);
-                }
-                $formattedNumber = $phoneNumberUtil->format($phoneNumber, $libFormat);
-            }
+            $formattedNumber = $this->formatWithLibPhoneNumber($rawPhoneNumber, $format);
         }
 
         if ($this->config->isPhoneNumberTrimWhitespace()) {
@@ -415,6 +384,51 @@ class AddressResolver
         }
 
         return $formattedNumber;
+    }
+
+    /**
+     * @param string $rawPhoneNumber
+     * @param mixed $format
+     * @return string
+     */
+    private function formatWithLibPhoneNumber(string $rawPhoneNumber, $format): string
+    {
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+        try {
+            $phoneNumber = $phoneNumberUtil->parse($rawPhoneNumber);
+        } catch (NumberParseException $e) {
+            $this->logger->error(sprintf(
+                'Unable to parse phone number "%s" for formatting: %s',
+                $rawPhoneNumber,
+                $e->getMessage()
+            ));
+            return $rawPhoneNumber;
+        }
+
+        if ($format === PhoneNumberFormat::COUNTRY_OPTION_VALUE) {
+            $country = $this->config->getPhoneNumberFormatCountry();
+            if (!$country) {
+                $this->logger->error(sprintf(
+                    'Unable to parse phone number "%s" for formatting. Country must be specified when country formatting is selected.',
+                    $rawPhoneNumber
+                ));
+                return $rawPhoneNumber;
+            }
+            return $phoneNumberUtil->formatOutOfCountryCallingNumber($phoneNumber, $country);
+        }
+
+        if ($format === 'raw') {
+            // 'raw' means no libphonenumber formatting — return as-is
+            return $rawPhoneNumber;
+        }
+
+        // libphonenumber v9 uses backed enums; cast stored int/string value to enum if needed
+        $libFormat = $format;
+        if (!($format instanceof \BackedEnum)) {
+            $libFormat = \libphonenumber\PhoneNumberFormat::from((int) $format);
+        }
+
+        return $phoneNumberUtil->format($phoneNumber, $libFormat);
     }
 
     /**

--- a/Model/AddressResolver.php
+++ b/Model/AddressResolver.php
@@ -179,8 +179,10 @@ class AddressResolver
         $customerAddress->setTelephone($phoneNumber);
 
         if ($region = $this->getRegion($amwalAddress)) {
-            $customerAddress->setRegion($region)
-                ->setRegionId((int) $region->getRegionId());
+            $customerAddress->setRegion($region);
+            if ($region->getRegionId()) {
+                $customerAddress->setRegionId((int) $region->getRegionId());
+            }
         }
 
         $cityId = $this->getCityId($amwalAddress);
@@ -395,8 +397,16 @@ class AddressResolver
                     return $rawPhoneNumber;
                 }
                 $formattedNumber = $phoneNumberUtil->formatOutOfCountryCallingNumber($phoneNumber, $country);
+            } elseif ($format === 'raw') {
+                // 'raw' means no libphonenumber formatting — return as-is
+                return $rawPhoneNumber;
             } else {
-                $formattedNumber = $phoneNumberUtil->format($phoneNumber, $format);
+                // libphonenumber v9 uses backed enums; cast stored int/string value to enum if needed
+                $libFormat = $format;
+                if (!($format instanceof \BackedEnum)) {
+                    $libFormat = \libphonenumber\PhoneNumberFormat::from((int) $format);
+                }
+                $formattedNumber = $phoneNumberUtil->format($phoneNumber, $libFormat);
             }
         }
 

--- a/Model/Checkout/GetQuote.php
+++ b/Model/Checkout/GetQuote.php
@@ -156,6 +156,7 @@ class GetQuote extends AmwalCheckoutAction
         ?string $cartId = null
     ): array {
         $quoteData = [];
+        $quote = null;
         $customerAddress = null;
         $availableRates = [];
 
@@ -186,7 +187,7 @@ class GetQuote extends AmwalCheckoutAction
                 $quote->setCustomerIsGuest(true);
             }
 
-            $amwalAddress = $this->amwalAddressFactory->create(['data' => $addressData]);
+            $amwalAddress = $this->amwalAddressFactory->create()->setData($addressData);
             if (!$isPreCheckout) {
                 $amwalOrderData = $this->objectFactory->create([
                     'client_first_name' => $addressData['client_first_name'] ?? AddressResolver::TEMPORARY_DATA_VALUE,
@@ -232,9 +233,10 @@ class GetQuote extends AmwalCheckoutAction
                 $this->logger->notice('Unable to log quote data debug message');
             }
         } catch (Throwable $e) {
+            $this->logger->error("Amwal GetQuote Exception: " . $e->getMessage() . "\n" . $e->getTraceAsString());
             $this->reportError($refId, $e->getMessage());
             $userMessage = $this->resolveExceptionMessage($e);
-            $this->throwException($userMessage, $e, $quote->getAmwalOrderId());
+            $this->throwException($userMessage, $e, $quote ? $quote->getAmwalOrderId() : null);
         }
 
         return $quoteData;
@@ -274,7 +276,7 @@ class GetQuote extends AmwalCheckoutAction
      * @return void
      * @throws LocalizedException
      */
-    private function throwException($message = null, Throwable $originalException = null, ?int $amwalOrderId = null): void
+    private function throwException($message = null, ?Throwable $originalException = null, ?string $amwalOrderId = null): void
     {
         if($originalException){
             $this->sentryExceptionReport->setTags('transaction_id', $amwalOrderId);


### PR DESCRIPTION
AddressResolver: only set regionId when region provides an ID to avoid casting null to int; add support for a 'raw' phone format (return original input) and handle libphonenumber v9 BackedEnum values by converting ints/strings to the enum before formatting.

GetQuote: initialize $quote to avoid undefined variable in exception paths; switch amwalAddress factory usage to create()->setData(...); improve exception logging with stack trace and make throwException calls null-safe (pass order id only if quote exists). Update throwException signature to accept nullable Throwable and a string order id.