### PR TITLE
Bump module version to 1.0.46

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -77,7 +77,7 @@ class Config
   /**
      * @var string
      */
-    const MODULE_VERSION = '1.0.45';
+    const MODULE_VERSION = '1.0.46';
 
     /** @var ScopeConfigInterface */
     private ScopeConfigInterface $scopeConfig;


### PR DESCRIPTION
Updates `Config::MODULE_VERSION` from `1.0.45` to `1.0.46` to reflect the next release of the payment module.