### PR TITLE
Use explicit nullable type hints in methods

### DIFF
--- a/Block/Product/ProductsList.php
+++ b/Block/Product/ProductsList.php
@@ -70,10 +70,10 @@ class ProductsList extends \Magento\CatalogWidget\Block\Product\ProductsList
         Config                      $config,
         StoreManagerInterface       $storeManager,
         array                       $data = [],
-        Json                        $json = null,
-        LayoutFactory               $layoutFactory = null,
-        EncoderInterface            $urlEncoder = null,
-        CategoryRepositoryInterface $categoryRepository = null
+        ?Json                        $json = null,
+        ?LayoutFactory               $layoutFactory = null,
+        ?EncoderInterface            $urlEncoder = null,
+        ?CategoryRepositoryInterface $categoryRepository = null
     ) {
         parent::__construct($context, $productCollectionFactory, $catalogProductVisibility, $httpContext, $sqlBuilder, $rule, $conditionsHelper, $data, $json, $layoutFactory, $urlEncoder, $categoryRepository);
         $this->config = $config;

--- a/Model/Button/GetCartButtonConfig.php
+++ b/Model/Button/GetCartButtonConfig.php
@@ -98,7 +98,7 @@ class GetCartButtonConfig extends GetConfig
      */
     public function execute(
         RefIdDataInterface $refIdData,
-        string $triggerContext = null,
+        ?string $triggerContext = null,
         ?string $cartId = null,
         ?string $productId = null
     ): AmwalButtonConfigInterface   {

--- a/Model/Checkout/PlaceOrder.php
+++ b/Model/Checkout/PlaceOrder.php
@@ -139,7 +139,7 @@ class PlaceOrder extends AmwalCheckoutAction
         string $amwalOrderId,
         string $triggerContext,
         bool $hasAmwalAddress,
-        string $card_bin = null,
+        ?string $card_bin = null,
         string $paymentMethod = ConfigProvider::CODE
     ): OrderInterface {
         $amwalOrderData = $this->getAmwalOrderData->execute($amwalOrderId);
@@ -407,7 +407,7 @@ class PlaceOrder extends AmwalCheckoutAction
      * @return void
      * @throws LocalizedException
      */
-    private function throwException($message = null, Throwable $originalException = null): void
+    private function throwException($message = null, ?Throwable $originalException = null): void
     {
         if ($originalException) {
             $this->sentryExceptionReport->report($originalException);

--- a/Model/CurrencyConverter.php
+++ b/Model/CurrencyConverter.php
@@ -51,7 +51,7 @@ class CurrencyConverter
      */
     public function convertAmount(
         float $amount,
-        Quote $quote = null,
+        ?Quote $quote = null,
         ?string $targetCurrency = null,
         bool $roundResult = true
     ): array {
@@ -100,7 +100,7 @@ class CurrencyConverter
      * @return float The converted amount in SAR.
      * @throws LocalizedException|NoSuchEntityException
      */
-    public function convertToSAR($amount, Quote $quote = null, bool $roundResult = true): float
+    public function convertToSAR($amount, ?Quote $quote = null, bool $roundResult = true): float
     {
         if ($amount === null || $amount === '' || $amount == 0) {
             return 0.0;
@@ -220,7 +220,7 @@ class CurrencyConverter
      * @return StoreInterface
      * @throws NoSuchEntityException
      */
-    private function getStore(Quote $quote = null): StoreInterface
+    private function getStore(?Quote $quote = null): StoreInterface
     {
         return $quote ? $quote->getStore() : $this->storeManager->getStore();
     }


### PR DESCRIPTION
Updated several method signatures to use explicit nullable types (`?Type`) where parameters default to `null` in product list, cart button config, checkout order placement, and currency conversion classes. This aligns the code with modern PHP typing expectations and avoids implicit-null signature issues.